### PR TITLE
Make Optimizer contain fsdp parameters

### DIFF
--- a/lightning_mingpt/models.py
+++ b/lightning_mingpt/models.py
@@ -137,7 +137,7 @@ class FSDPGPT(GPT):
         self.save_hyperparameters()
 
     def configure_optimizers(self):
-        optimizer = super().configure_optimizers()
+        optimizer = self.mingpt.configure_optimizers(self.mingpt_trainer_config, self.trainer.model)
         optim_groups = optimizer.param_groups
 
         return AdamW(optim_groups, lr=self.hparams.learning_rate, betas=self.hparams.betas)

--- a/mingpt/model.py
+++ b/mingpt/model.py
@@ -210,20 +210,22 @@ class GPT(nn.Module):
 
         return model
 
-    def configure_optimizers(self, train_config):
+    def configure_optimizers(self, train_config, model: Optional[torch.nn.Module] = None):
         """This long function is unfortunately doing something very simple and is being very defensive:
 
         We are separating out all parameters of the model into two buckets: those that will experience weight decay for
         regularization and those that won't (biases, and layernorm/embedding weights). We are then returning the PyTorch
         optimizer object.
         """
+        
+        model = model or self
 
         # separate out all parameters to those that will and won't experience regularizing weight decay
         decay = set()
         no_decay = set()
         whitelist_weight_modules = (torch.nn.Linear, )
         blacklist_weight_modules = (torch.nn.LayerNorm, torch.nn.Embedding)
-        for mn, m in self.named_modules():
+        for mn, m in model.named_modules():
             for pn, p in m.named_parameters():
                 fpn = f'{mn}.{pn}' if mn else pn # full param name
                 # random note: because named_modules and named_parameters are recursive

--- a/mingpt/model.py
+++ b/mingpt/model.py
@@ -242,7 +242,7 @@ class GPT(nn.Module):
                     no_decay.add(fpn)
 
         # validate that we considered every parameter
-        param_dict = {pn: p for pn, p in self.named_parameters()}
+        param_dict = {pn: p for pn, p in model.named_parameters()}
         inter_params = decay & no_decay
         union_params = decay | no_decay
         assert len(inter_params) == 0, f"parameters {str(inter_params)} made it into both decay/no_decay sets!"


### PR DESCRIPTION
Without these changes, fsdp won't run and you get

```python
ValueError: The optimizer does not seem to reference any FSDP parameters. HINT: Make sure to create the optimizer after setting up the model by referencing `self.trainer.model.parameters()` in the `configure_optimizers()` hook.
```